### PR TITLE
Add support for .jpeg and .ovpn files

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,9 +34,12 @@ fi
 
 DATA="${DATA}/icons-in-terminal/"
 ICONS_HEADER="${DATA}/icons-in-terminal.h"
+ICONS_HEADER_ARCH="/etc/icons-in-terminal/icons-in-terminal.h"
 
 if [ -f "$ICONS_HEADER" ]; then
     ln -fs $ICONS_HEADER ./src/
+elif [ -f "$ICONS_HEADER_ARCH" ]; then
+    ln -fs $ICONS_HEADER_ARCH ./src/
 else
     echo "Cannot find icons-in-terminal, are you sure it's installed ?"
     echo "If you installed it this message is an error, please open an issue:"

--- a/bootstrap
+++ b/bootstrap
@@ -34,7 +34,7 @@ fi
 
 DATA="${DATA}/icons-in-terminal/"
 ICONS_HEADER="${DATA}/icons-in-terminal.h"
-ICONS_HEADER_ARCH="/etc/icons-in-terminal/icons-in-terminal.h"
+ICONS_HEADER_ARCH="/usr/share/icons-in-terminal/icons-in-terminal.h"
 
 if [ -f "$ICONS_HEADER" ]; then
     ln -fs $ICONS_HEADER ./src/

--- a/src/ls-icons.c
+++ b/src/ls-icons.c
@@ -276,6 +276,7 @@ static t_file_matching file_matches[] = {
   { MD_VPN_KEY, MATCH( P("id_rsa") ), RED},
   { MD_VPN_KEY, MATCH( S(".crt") ), BLUE},
   { MD_VPN_KEY, MATCH( S(".pem") ), ORANGE},
+  { MD_VPN_KEY, MATCH( S(".ovpn") ), DARK_ORANGE},
   { MD_VPN_KEY, MATCH( S(".pub") ), YELLOW},
   { MD_VPN_KEY, MATCH( S(".key") ), BLUE},
   { DEV_BOWER, MATCH( S(".bowerrc", "bower.json", "Bowerfile") ), YELLOW},

--- a/src/ls-icons.c
+++ b/src/ls-icons.c
@@ -288,6 +288,7 @@ static t_file_matching file_matches[] = {
   { FA_FILE_IMAGE_O, MATCH( S(".webp") ), DARK_BLUE},
   { FA_FILE_IMAGE_O, MATCH( S(".ico") ), BLUE},
   { FA_FILE_IMAGE_O, MATCH( S(".jpg") ), GREEN},
+  { FA_FILE_IMAGE_O, MATCH( S(".jpeg") ), GREEN},
   { FA_FILE_IMAGE_O, MATCH( S(".gif") ), YELLOW},
   { FA_FILE_IMAGE_O, MATCH( S(".png") ), ORANGE},
   { FILE_OPENOFFICE, MATCH( S(".odt") ), BLUE},


### PR DESCRIPTION
Adds support in bootstrap for icons-in-terminal installations from AUR.
Adds support for .jpeg (Green).
Adds support for .ovpn (Dark-Orange).

